### PR TITLE
feat: data-driven project categories + stub pages for Anytime, Inspect, GhostTile

### DIFF
--- a/public/assets/images/project-anytime.png
+++ b/public/assets/images/project-anytime.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166694e973224fb4c32abeb740bb5a81b0984db1f9221390bbf2e8644bf151e6
+size 278309

--- a/public/assets/images/project-miso.png
+++ b/public/assets/images/project-miso.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:230bb82d3a8c2512b37b757dd2fef34e699420b31f521f3d3c7656f56931fd96
+size 251523

--- a/src/components/NavMenuItem.tsx
+++ b/src/components/NavMenuItem.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react';
+
 type INavMenuItemProps = {
   href: string;
-  children: string;
+  children: ReactNode;
   target?: '_blank' | '_self' | '_parent' | '_top' | string;
 };
 

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -16,7 +16,7 @@ const Project = (props: IProjectProps) => (
     <div className="shrink-0">
       <a href={props.link}>
         <img
-          className="h-36 w-36 hover:translate-y-1"
+          className="h-36 w-36 rounded-2xl hover:translate-y-1"
           src={props.img.src}
           alt={props.img.alt}
           loading="lazy"

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -145,7 +145,7 @@ export const projects: ProjectEntry[] = [
     ],
     link: {
       kind: 'external',
-      url: 'https://github.com/hewigovens/StagedLauncher',
+      url: 'https://a1.hewig.dev/staged/',
     },
   },
   {

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -39,8 +39,44 @@ export const categoryOrder: ProjectCategory[] = [
   'contributions',
 ];
 
+/** Resolve a ProjectLink to a plain URL string. */
+export function resolveLink(entry: ProjectEntry): string {
+  return entry.link.kind === 'internal' ? entry.link.path : entry.link.url;
+}
+
+/**
+ * All projects. Array order = recency (newest first) for the home page.
+ * The `category` field drives grouping on the All Projects page.
+ */
 export const projects: ProjectEntry[] = [
-  // ── Rust ──────────────────────────────────────────────
+  {
+    name: 'amux',
+    description:
+      'A tiny Rust CLI that keeps your fleet of local AI/code agents organised inside tmux with consistent commands to launch, attach, detach, and prune sessions.',
+    img: { src: '/assets/images/project-amux.svg', alt: 'amux CLI' },
+    category: 'rust',
+    tags: [
+      { color: ColorTags.RUST, label: 'Rust' },
+      { color: ColorTags.SLATE, label: 'CLI' },
+      { color: ColorTags.GREEN, label: 'tmux' },
+      { color: ColorTags.INDIGO, label: 'Agents' },
+    ],
+    link: { kind: 'external', url: 'https://github.com/hewigovens/amux' },
+  },
+  {
+    name: 'Miso',
+    description:
+      'A lightweight macOS menu bar utility providing a floating HUD overlay for quick input method switching. Zero permissions required.',
+    img: { src: '/assets/images/project-miso.png', alt: 'Miso' },
+    category: 'macos',
+    tags: [
+      { color: ColorTags.SWIFT, label: 'Swift' },
+      { color: ColorTags.FUCHSIA, label: 'macOS' },
+      { color: ColorTags.SLATE, label: 'Menu Bar' },
+      { color: ColorTags.EMERALD, label: 'Input Method' },
+    ],
+    link: { kind: 'external', url: 'https://github.com/hewigovens/miso' },
+  },
   {
     name: 'hw-core',
     description:
@@ -56,18 +92,24 @@ export const projects: ProjectEntry[] = [
     link: { kind: 'external', url: 'https://github.com/hewigovens/hw-core' },
   },
   {
-    name: 'amux',
+    name: 'App Detective',
     description:
-      'A tiny Rust CLI that keeps your fleet of local AI/code agents organised inside tmux with consistent commands to launch, attach, detach, and prune sessions.',
-    img: { src: '/assets/images/project-amux.svg', alt: 'amux CLI' },
-    category: 'rust',
+      "A tool to detect macOS apps' GUI tech stack, helping developers understand the underlying technologies used in applications.",
+    img: {
+      src: '/assets/images/project-app-detective.png',
+      alt: 'App Detective',
+    },
+    category: 'macos',
     tags: [
-      { color: ColorTags.RUST, label: 'Rust' },
-      { color: ColorTags.SLATE, label: 'CLI' },
-      { color: ColorTags.GREEN, label: 'tmux' },
-      { color: ColorTags.INDIGO, label: 'Agents' },
+      { color: ColorTags.SWIFT, label: 'Swift' },
+      { color: ColorTags.FUCHSIA, label: 'macOS' },
+      { color: ColorTags.VIOLET, label: 'Reverse Engineering' },
+      { color: ColorTags.EMERALD, label: 'Diagnostics' },
     ],
-    link: { kind: 'external', url: 'https://github.com/hewigovens/amux' },
+    link: {
+      kind: 'external',
+      url: 'https://github.com/hewigovens/app-detective',
+    },
   },
   {
     name: 'Solana Primitives',
@@ -87,20 +129,23 @@ export const projects: ProjectEntry[] = [
     },
   },
   {
-    name: 'reqwest-enum',
+    name: 'Staged Launcher',
     description:
-      'Type-safe and enum style API for Rust, it abstracts away repetitive boilerplate code like url formatting, query / header encoding and response deserialization, plus async by default and lightweight JSON-RPC support.',
-    img: { src: '/assets/images/project-cargo.png', alt: 'reqwest-enum' },
-    category: 'rust',
+      'The easiest way to manage and delay the launch of applications across different stages on your Mac.',
+    img: {
+      src: '/assets/images/project-staged-launcher.png',
+      alt: 'Staged Launcher',
+    },
+    category: 'macos',
     tags: [
-      { color: ColorTags.RUST, label: 'Rust' },
-      { color: ColorTags.SWIFT, label: 'Enum' },
-      { color: ColorTags.SKY, label: 'HTTP' },
-      { color: ColorTags.LIME, label: 'JSONRPC' },
+      { color: ColorTags.SWIFT, label: 'Swift' },
+      { color: ColorTags.FUCHSIA, label: 'macOS' },
+      { color: ColorTags.ROSE, label: 'Productivity' },
+      { color: ColorTags.INDIGO, label: 'Automation' },
     ],
     link: {
       kind: 'external',
-      url: 'https://github.com/hewigovens/reqwest-enum',
+      url: 'https://github.com/hewigovens/StagedLauncher',
     },
   },
   {
@@ -123,46 +168,21 @@ export const projects: ProjectEntry[] = [
       url: 'https://github.com/hewigovens/aya-devcontainer',
     },
   },
-
-  // ── macOS ─────────────────────────────────────────────
   {
-    name: 'App Detective',
+    name: 'reqwest-enum',
     description:
-      "A tool to detect macOS apps' GUI tech stack, helping developers understand the underlying technologies used in applications.",
-    img: {
-      src: '/assets/images/project-app-detective.png',
-      alt: 'App Detective',
-    },
-    category: 'macos',
+      'Type-safe and enum style API for Rust, it abstracts away repetitive boilerplate code like url formatting, query / header encoding and response deserialization, plus async by default and lightweight JSON-RPC support.',
+    img: { src: '/assets/images/project-cargo.png', alt: 'reqwest-enum' },
+    category: 'rust',
     tags: [
-      { color: ColorTags.SWIFT, label: 'Swift' },
-      { color: ColorTags.FUCHSIA, label: 'macOS' },
-      { color: ColorTags.VIOLET, label: 'Reverse Engineering' },
-      { color: ColorTags.EMERALD, label: 'Diagnostics' },
+      { color: ColorTags.RUST, label: 'Rust' },
+      { color: ColorTags.SWIFT, label: 'Enum' },
+      { color: ColorTags.SKY, label: 'HTTP' },
+      { color: ColorTags.LIME, label: 'JSONRPC' },
     ],
     link: {
       kind: 'external',
-      url: 'https://github.com/hewigovens/app-detective',
-    },
-  },
-  {
-    name: 'Staged Launcher',
-    description:
-      'The easiest way to manage and delay the launch of applications across different stages on your Mac.',
-    img: {
-      src: '/assets/images/project-staged-launcher.png',
-      alt: 'Staged Launcher',
-    },
-    category: 'macos',
-    tags: [
-      { color: ColorTags.SWIFT, label: 'Swift' },
-      { color: ColorTags.FUCHSIA, label: 'macOS' },
-      { color: ColorTags.ROSE, label: 'Productivity' },
-      { color: ColorTags.INDIGO, label: 'Automation' },
-    ],
-    link: {
-      kind: 'external',
-      url: 'https://github.com/hewigovens/StagedLauncher',
+      url: 'https://github.com/hewigovens/reqwest-enum',
     },
   },
   {
@@ -189,7 +209,7 @@ export const projects: ProjectEntry[] = [
       src: '/assets/images/project-anytime.png',
       alt: 'Anytime',
     },
-    category: 'macos',
+    category: 'ios',
     tags: [
       { color: ColorTags.SWIFT, label: 'Swift' },
       { color: ColorTags.FUCHSIA, label: 'macOS' },
@@ -198,8 +218,6 @@ export const projects: ProjectEntry[] = [
     ],
     link: { kind: 'internal', path: '/projects/anytime' },
   },
-
-  // ── iOS ───────────────────────────────────────────────
   {
     name: 'Inspect',
     description:
@@ -217,8 +235,6 @@ export const projects: ProjectEntry[] = [
     ],
     link: { kind: 'internal', path: '/projects/inspect' },
   },
-
-  // ── Contributions ─────────────────────────────────────
   {
     name: 'Wallet Core',
     description:

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,242 @@
+import { ColorTags } from '@/components/Tags';
+
+import type { Values } from '@/components/types/TypeUnion';
+
+export type ProjectCategory = 'rust' | 'macos' | 'ios' | 'contributions';
+
+export type ProjectLink =
+  | { kind: 'internal'; path: string }
+  | { kind: 'external'; url: string };
+
+export type TagEntry = {
+  color: Values<typeof ColorTags>;
+  label: string;
+};
+
+export type ProjectEntry = {
+  name: string;
+  description: string;
+  img: { src: string; alt: string };
+  category: ProjectCategory;
+  tags: TagEntry[];
+  link: ProjectLink;
+};
+
+export const categoryLabels: Record<
+  ProjectCategory,
+  { prefix: string; highlight: string }
+> = {
+  rust: { prefix: 'Rust', highlight: 'Libraries & Tools' },
+  macos: { prefix: 'macOS', highlight: 'Apps' },
+  ios: { prefix: 'iOS', highlight: 'Apps' },
+  contributions: { prefix: 'Open Source', highlight: 'Contributions' },
+};
+
+export const categoryOrder: ProjectCategory[] = [
+  'rust',
+  'macos',
+  'ios',
+  'contributions',
+];
+
+export const projects: ProjectEntry[] = [
+  // ── Rust ──────────────────────────────────────────────
+  {
+    name: 'hw-core',
+    description:
+      'Cross platform hardware wallet interface. A Rust-based library implementing low-level wallet functionality, including Trezor Host Protocol.',
+    img: { src: '/assets/images/project-hw-core.png', alt: 'hw-core' },
+    category: 'rust',
+    tags: [
+      { color: ColorTags.RUST, label: 'Rust' },
+      { color: ColorTags.CYAN, label: 'Hardware Wallet' },
+      { color: ColorTags.GREEN, label: 'Trezor' },
+      { color: ColorTags.INDIGO, label: 'BLE' },
+    ],
+    link: { kind: 'external', url: 'https://github.com/hewigovens/hw-core' },
+  },
+  {
+    name: 'amux',
+    description:
+      'A tiny Rust CLI that keeps your fleet of local AI/code agents organised inside tmux with consistent commands to launch, attach, detach, and prune sessions.',
+    img: { src: '/assets/images/project-amux.svg', alt: 'amux CLI' },
+    category: 'rust',
+    tags: [
+      { color: ColorTags.RUST, label: 'Rust' },
+      { color: ColorTags.SLATE, label: 'CLI' },
+      { color: ColorTags.GREEN, label: 'tmux' },
+      { color: ColorTags.INDIGO, label: 'Agents' },
+    ],
+    link: { kind: 'external', url: 'https://github.com/hewigovens/amux' },
+  },
+  {
+    name: 'Solana Primitives',
+    description:
+      'A Rust crate providing fundamental data structures and tools for constructing and submitting Solana transactions.',
+    img: { src: '/assets/images/project-cargo.png', alt: 'Solana Primitives' },
+    category: 'rust',
+    tags: [
+      { color: ColorTags.RUST, label: 'Rust' },
+      { color: ColorTags.LIME, label: 'Blockchain' },
+      { color: ColorTags.VIOLET, label: 'Solana' },
+      { color: ColorTags.INDIGO, label: 'SDK' },
+    ],
+    link: {
+      kind: 'external',
+      url: 'https://github.com/hewigovens/solana-primitives',
+    },
+  },
+  {
+    name: 'reqwest-enum',
+    description:
+      'Type-safe and enum style API for Rust, it abstracts away repetitive boilerplate code like url formatting, query / header encoding and response deserialization, plus async by default and lightweight JSON-RPC support.',
+    img: { src: '/assets/images/project-cargo.png', alt: 'reqwest-enum' },
+    category: 'rust',
+    tags: [
+      { color: ColorTags.RUST, label: 'Rust' },
+      { color: ColorTags.SWIFT, label: 'Enum' },
+      { color: ColorTags.SKY, label: 'HTTP' },
+      { color: ColorTags.LIME, label: 'JSONRPC' },
+    ],
+    link: {
+      kind: 'external',
+      url: 'https://github.com/hewigovens/reqwest-enum',
+    },
+  },
+  {
+    name: 'Aya DevContainer',
+    description:
+      'DevContainer (Docker) image for Aya-rs, providing a pre-configured development environment for eBPF programming with Rust.',
+    img: {
+      src: '/assets/images/project-aya-container.png',
+      alt: 'Aya DevContainer',
+    },
+    category: 'rust',
+    tags: [
+      { color: ColorTags.RUST, label: 'Rust' },
+      { color: ColorTags.BLUE, label: 'Docker' },
+      { color: ColorTags.VIOLET, label: 'eBPF' },
+      { color: ColorTags.EMERALD, label: 'DevContainer' },
+    ],
+    link: {
+      kind: 'external',
+      url: 'https://github.com/hewigovens/aya-devcontainer',
+    },
+  },
+
+  // ── macOS ─────────────────────────────────────────────
+  {
+    name: 'App Detective',
+    description:
+      "A tool to detect macOS apps' GUI tech stack, helping developers understand the underlying technologies used in applications.",
+    img: {
+      src: '/assets/images/project-app-detective.png',
+      alt: 'App Detective',
+    },
+    category: 'macos',
+    tags: [
+      { color: ColorTags.SWIFT, label: 'Swift' },
+      { color: ColorTags.FUCHSIA, label: 'macOS' },
+      { color: ColorTags.VIOLET, label: 'Reverse Engineering' },
+      { color: ColorTags.EMERALD, label: 'Diagnostics' },
+    ],
+    link: {
+      kind: 'external',
+      url: 'https://github.com/hewigovens/app-detective',
+    },
+  },
+  {
+    name: 'Staged Launcher',
+    description:
+      'The easiest way to manage and delay the launch of applications across different stages on your Mac.',
+    img: {
+      src: '/assets/images/project-staged-launcher.png',
+      alt: 'Staged Launcher',
+    },
+    category: 'macos',
+    tags: [
+      { color: ColorTags.SWIFT, label: 'Swift' },
+      { color: ColorTags.FUCHSIA, label: 'macOS' },
+      { color: ColorTags.ROSE, label: 'Productivity' },
+      { color: ColorTags.INDIGO, label: 'Automation' },
+    ],
+    link: {
+      kind: 'external',
+      url: 'https://github.com/hewigovens/StagedLauncher',
+    },
+  },
+  {
+    name: 'GhostTile',
+    description: 'Hide your running applications from Dock like a charm.',
+    img: {
+      src: '/assets/images/project-ghost.png',
+      alt: 'GhostTile macOS app',
+    },
+    category: 'macos',
+    tags: [
+      { color: ColorTags.OBJC, label: 'ObjcC' },
+      { color: ColorTags.GREEN, label: 'XPC' },
+      { color: ColorTags.ROSE, label: 'Code injection' },
+      { color: ColorTags.FUCHSIA, label: 'macOS' },
+    ],
+    link: { kind: 'internal', path: '/projects/ghosttile' },
+  },
+  {
+    name: 'Anytime',
+    description:
+      'A timezone-aware world clock app for Mac and iPhone. Quickly see what time it is for your team, anywhere.',
+    img: {
+      src: '/assets/images/project-anytime.png',
+      alt: 'Anytime',
+    },
+    category: 'macos',
+    tags: [
+      { color: ColorTags.SWIFT, label: 'Swift' },
+      { color: ColorTags.FUCHSIA, label: 'macOS' },
+      { color: ColorTags.SKY, label: 'iOS' },
+      { color: ColorTags.EMERALD, label: 'Productivity' },
+    ],
+    link: { kind: 'internal', path: '/projects/anytime' },
+  },
+
+  // ── iOS ───────────────────────────────────────────────
+  {
+    name: 'Inspect',
+    description:
+      "Inspect is an action extension (works in both Safari, Chrome and Edge) that allows you to inspect and export website's https certificate information.",
+    img: {
+      src: '/assets/images/project-inspect.png',
+      alt: 'Inspect iOS app',
+    },
+    category: 'ios',
+    tags: [
+      { color: ColorTags.SWIFT, label: 'Swift' },
+      { color: ColorTags.INDIGO, label: 'TLS' },
+      { color: ColorTags.BLUE, label: 'OpenSSL' },
+      { color: ColorTags.FUCHSIA, label: 'iOS' },
+    ],
+    link: { kind: 'internal', path: '/projects/inspect' },
+  },
+
+  // ── Contributions ─────────────────────────────────────
+  {
+    name: 'Wallet Core',
+    description:
+      'Trust Wallet Core is an open-source, cross-platform, mobile-focused library implementing low-level cryptographic wallet functionality for a high number of blockchains.',
+    img: {
+      src: '/assets/images/project-wallet-core.png',
+      alt: 'Wallet Core',
+    },
+    category: 'contributions',
+    tags: [
+      { color: ColorTags.CPP, label: 'C++' },
+      { color: ColorTags.YELLOW, label: 'Cross Platform' },
+      { color: ColorTags.WEBASSEMBLY, label: 'Web Assembly' },
+      { color: ColorTags.FUCHSIA, label: 'SDK' },
+    ],
+    link: {
+      kind: 'external',
+      url: 'https://github.com/trustwallet/wallet-core',
+    },
+  },
+];

--- a/src/pages/projects/anytime.astro
+++ b/src/pages/projects/anytime.astro
@@ -1,0 +1,46 @@
+---
+import { Section } from "@/components";
+import { GradientText } from "@/components";
+import { ColorTags, Tags } from "@/components/Tags";
+import Base from "@/templates/Base.astro";
+
+const title = "Anytime – World Clock";
+const description =
+  "A timezone-aware world clock app for Mac and iPhone. Quickly see what time it is for your team, anywhere.";
+---
+
+<Base head={{ title, description }}>
+  <Section>
+    <div class="mx-auto max-w-2xl">
+      <div class="flex flex-col items-center gap-6 rounded-lg border border-gray-700 bg-slate-800 p-8">
+        <img
+          class="h-32 w-32 rounded-2xl"
+          src="/assets/images/project-anytime.png"
+          alt="Anytime"
+        />
+
+        <h1 class="text-3xl font-bold">
+          <GradientText>Anytime</GradientText>
+        </h1>
+
+        <p class="text-center text-gray-300">
+          {description}
+        </p>
+
+        <div class="flex flex-wrap justify-center gap-2">
+          <Tags color={ColorTags.SWIFT}>Swift</Tags>
+          <Tags color={ColorTags.FUCHSIA}>macOS</Tags>
+          <Tags color={ColorTags.SKY}>iOS</Tags>
+          <Tags color={ColorTags.EMERALD}>Productivity</Tags>
+        </div>
+
+        <a
+          href="#"
+          class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
+        >
+          Download on the App Store
+        </a>
+      </div>
+    </div>
+  </Section>
+</Base>

--- a/src/pages/projects/anytime.astro
+++ b/src/pages/projects/anytime.astro
@@ -34,12 +34,20 @@ const description =
           <Tags color={ColorTags.EMERALD}>Productivity</Tags>
         </div>
 
-        <a
-          href="https://apps.apple.com/us/app/anytime-timezone-calculator/id1291735859"
-          class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
-        >
-          Download on the App Store
-        </a>
+        <div class="flex flex-wrap justify-center gap-4">
+          <a
+            href="https://apps.apple.com/us/app/anytime-timezone-calculator/id1291735859"
+            class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
+          >
+            Download on the App Store
+          </a>
+          <a
+            href="https://fourplexlabs.github.io/AnyTime/"
+            class="inline-block rounded-lg border border-cyan-600 px-6 py-3 font-semibold text-cyan-400 transition hover:bg-cyan-600/10"
+          >
+            Visit Website
+          </a>
+        </div>
       </div>
     </div>
   </Section>

--- a/src/pages/projects/anytime.astro
+++ b/src/pages/projects/anytime.astro
@@ -35,7 +35,7 @@ const description =
         </div>
 
         <a
-          href="#"
+          href="https://apps.apple.com/us/app/anytime-timezone-calculator/id1291735859"
           class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
         >
           Download on the App Store

--- a/src/pages/projects/anytime.astro
+++ b/src/pages/projects/anytime.astro
@@ -39,7 +39,7 @@ const description =
             href="https://apps.apple.com/us/app/anytime-timezone-calculator/id1291735859"
             class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
           >
-            Download on the App Store
+            Download
           </a>
           <a
             href="https://fourplexlabs.github.io/AnyTime/"

--- a/src/pages/projects/ghosttile.astro
+++ b/src/pages/projects/ghosttile.astro
@@ -1,0 +1,46 @@
+---
+import { Section } from "@/components";
+import { GradientText } from "@/components";
+import { ColorTags, Tags } from "@/components/Tags";
+import Base from "@/templates/Base.astro";
+
+const title = "GhostTile – Hide Apps from Dock";
+const description =
+  "Hide your running applications from Dock like a charm.";
+---
+
+<Base head={{ title, description }}>
+  <Section>
+    <div class="mx-auto max-w-2xl">
+      <div class="flex flex-col items-center gap-6 rounded-lg border border-gray-700 bg-slate-800 p-8">
+        <img
+          class="h-32 w-32 rounded-2xl"
+          src="/assets/images/project-ghost.png"
+          alt="GhostTile macOS app"
+        />
+
+        <h1 class="text-3xl font-bold">
+          <GradientText>GhostTile</GradientText>
+        </h1>
+
+        <p class="text-center text-gray-300">
+          {description}
+        </p>
+
+        <div class="flex flex-wrap justify-center gap-2">
+          <Tags color={ColorTags.OBJC}>ObjcC</Tags>
+          <Tags color={ColorTags.GREEN}>XPC</Tags>
+          <Tags color={ColorTags.ROSE}>Code injection</Tags>
+          <Tags color={ColorTags.FUCHSIA}>macOS</Tags>
+        </div>
+
+        <a
+          href="https://ghosttile.kernelpanic.im/"
+          class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
+        >
+          Visit GhostTile
+        </a>
+      </div>
+    </div>
+  </Section>
+</Base>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,11 @@
+---
+import { ProjectsByCategory } from "@/partials/ProjectsByCategory";
+import Base from "@/templates/Base.astro";
+
+const title = "All Projects";
+const description = "Browse all projects by category.";
+---
+
+<Base head={{ title, description }}>
+  <ProjectsByCategory />
+</Base>

--- a/src/pages/projects/inspect.astro
+++ b/src/pages/projects/inspect.astro
@@ -39,7 +39,7 @@ const description =
             href="https://apps.apple.com/us/app/inspect-view-tls-certificate/id1074957486"
             class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
           >
-            Download on the App Store
+            Download
           </a>
           <a
             href="https://fourplexlabs.github.io/Inspect"

--- a/src/pages/projects/inspect.astro
+++ b/src/pages/projects/inspect.astro
@@ -11,7 +11,7 @@ const description =
 
 <Base head={{ title, description }}>
   <Section>
-    <div class="mx-auto max-w-2xl">
+    <div class="mx-auto max-w-4xl">
       <div class="flex flex-col items-center gap-6 rounded-lg border border-gray-700 bg-slate-800 p-8">
         <img
           class="h-32 w-32 rounded-2xl"

--- a/src/pages/projects/inspect.astro
+++ b/src/pages/projects/inspect.astro
@@ -1,0 +1,46 @@
+---
+import { Section } from "@/components";
+import { GradientText } from "@/components";
+import { ColorTags, Tags } from "@/components/Tags";
+import Base from "@/templates/Base.astro";
+
+const title = "Inspect – View TLS Certificate";
+const description =
+  "Inspect is an action extension (works in both Safari, Chrome and Edge) that allows you to inspect and export website's https certificate information.";
+---
+
+<Base head={{ title, description }}>
+  <Section>
+    <div class="mx-auto max-w-2xl">
+      <div class="flex flex-col items-center gap-6 rounded-lg border border-gray-700 bg-slate-800 p-8">
+        <img
+          class="h-32 w-32 rounded-2xl"
+          src="/assets/images/project-inspect.png"
+          alt="Inspect iOS app"
+        />
+
+        <h1 class="text-3xl font-bold">
+          <GradientText>Inspect</GradientText>
+        </h1>
+
+        <p class="text-center text-gray-300">
+          {description}
+        </p>
+
+        <div class="flex flex-wrap justify-center gap-2">
+          <Tags color={ColorTags.SWIFT}>Swift</Tags>
+          <Tags color={ColorTags.INDIGO}>TLS</Tags>
+          <Tags color={ColorTags.BLUE}>OpenSSL</Tags>
+          <Tags color={ColorTags.FUCHSIA}>iOS</Tags>
+        </div>
+
+        <a
+          href="https://apps.apple.com/us/app/inspect-view-tls-certificate/id1074957486"
+          class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
+        >
+          Download on the App Store
+        </a>
+      </div>
+    </div>
+  </Section>
+</Base>

--- a/src/pages/projects/inspect.astro
+++ b/src/pages/projects/inspect.astro
@@ -34,12 +34,20 @@ const description =
           <Tags color={ColorTags.FUCHSIA}>iOS</Tags>
         </div>
 
-        <a
-          href="https://apps.apple.com/us/app/inspect-view-tls-certificate/id1074957486"
-          class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
-        >
-          Download on the App Store
-        </a>
+        <div class="flex flex-wrap justify-center gap-4">
+          <a
+            href="https://apps.apple.com/us/app/inspect-view-tls-certificate/id1074957486"
+            class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
+          >
+            Download on the App Store
+          </a>
+          <a
+            href="https://fourplexlabs.github.io/Inspect"
+            class="inline-block rounded-lg border border-cyan-600 px-6 py-3 font-semibold text-cyan-400 transition hover:bg-cyan-600/10"
+          >
+            Visit Website
+          </a>
+        </div>
       </div>
     </div>
   </Section>

--- a/src/partials/Navbar.tsx
+++ b/src/partials/Navbar.tsx
@@ -34,9 +34,38 @@ const Navbar = () => (
       </a>
 
       <NavMenu>
-        <NavMenuItem href="https://a1.hewig.dev">📊 Glance</NavMenuItem>
-        <NavMenuItem href="/posts/">✍️ Blog</NavMenuItem>
-        <NavMenuItem href="/consulting/">💼 Consulting</NavMenuItem>
+        <NavMenuItem href="/projects/">
+          <span className="inline-flex items-center gap-1">
+            <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+            </svg>
+            Projects
+          </span>
+        </NavMenuItem>
+        <NavMenuItem href="https://a1.hewig.dev">
+          <span className="inline-flex items-center gap-1">
+            <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+            </svg>
+            Glance
+          </span>
+        </NavMenuItem>
+        <NavMenuItem href="/posts/">
+          <span className="inline-flex items-center gap-1">
+            <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+            </svg>
+            Blog
+          </span>
+        </NavMenuItem>
+        <NavMenuItem href="/consulting/">
+          <span className="inline-flex items-center gap-1">
+            <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+            </svg>
+            Consulting
+          </span>
+        </NavMenuItem>
       </NavMenu>
     </NavbarTwoColumns>
   </Section>

--- a/src/partials/ProjectList.tsx
+++ b/src/partials/ProjectList.tsx
@@ -1,63 +1,36 @@
 import { Project, Section, Tags } from '@/components';
 import { GradientText } from '@/components/GradientText';
-import {
-  categoryLabels,
-  categoryOrder,
-  projects,
-} from '@/data/projects';
-import type { ProjectEntry } from '@/data/projects';
+import { projects, resolveLink } from '@/data/projects';
 
-function resolveLink(entry: ProjectEntry): string {
-  return entry.link.kind === 'internal' ? entry.link.path : entry.link.url;
-}
-
-const ProjectList = () => {
-  const grouped = categoryOrder.map((cat) => ({
-    category: cat,
-    label: categoryLabels[cat],
-    items: projects.filter((p) => p.category === cat),
-  }));
-
-  return (
-    <Section
-      title={
-        <>
-          Recent <GradientText>Projects</GradientText>
-        </>
-      }
-    >
-      <div className="flex flex-col gap-10">
-        {grouped.map(({ category, label, items }) => (
-          <div key={category}>
-            <h3 className="text-lg font-semibold mb-4 text-gray-300">
-              {label.prefix}{' '}
-              <GradientText>{label.highlight}</GradientText>
-            </h3>
-            <div className="flex flex-col gap-6">
-              {items.map((entry) => (
-                <Project
-                  key={entry.name}
-                  name={entry.name}
-                  description={entry.description}
-                  link={resolveLink(entry)}
-                  img={entry.img}
-                  category={
-                    <>
-                      {entry.tags.map((tag) => (
-                        <Tags key={tag.label} color={tag.color}>
-                          {tag.label}
-                        </Tags>
-                      ))}
-                    </>
-                  }
-                />
+const ProjectList = () => (
+  <Section
+    title={
+      <>
+        Recent <GradientText>Projects</GradientText>
+      </>
+    }
+  >
+    <div className="flex flex-col gap-6">
+      {projects.map((entry) => (
+        <Project
+          key={entry.name}
+          name={entry.name}
+          description={entry.description}
+          link={resolveLink(entry)}
+          img={entry.img}
+          category={
+            <>
+              {entry.tags.map((tag) => (
+                <Tags key={tag.label} color={tag.color}>
+                  {tag.label}
+                </Tags>
               ))}
-            </div>
-          </div>
-        ))}
-      </div>
-    </Section>
-  );
-};
+            </>
+          }
+        />
+      ))}
+    </div>
+  </Section>
+);
 
 export { ProjectList };

--- a/src/partials/ProjectList.tsx
+++ b/src/partials/ProjectList.tsx
@@ -2,6 +2,21 @@ import { Project, Section, Tags } from '@/components';
 import { GradientText } from '@/components/GradientText';
 import { projects, resolveLink } from '@/data/projects';
 
+const recentNames = [
+  'hw-core',
+  'Solana Primitives',
+  'Inspect',
+  'App Detective',
+  'Staged Launcher',
+  'Miso',
+  'Wallet Core',
+  'GhostTile',
+];
+
+const recentProjects = recentNames
+  .map((name) => projects.find((p) => p.name === name)!)
+  .filter(Boolean);
+
 const ProjectList = () => (
   <Section
     title={
@@ -11,7 +26,7 @@ const ProjectList = () => (
     }
   >
     <div className="flex flex-col gap-6">
-      {projects.map((entry) => (
+      {recentProjects.map((entry) => (
         <Project
           key={entry.name}
           name={entry.name}
@@ -29,6 +44,18 @@ const ProjectList = () => (
           }
         />
       ))}
+    </div>
+
+    <div className="mt-8 text-center">
+      <a
+        className="inline-flex items-center gap-1 text-cyan-400 hover:text-cyan-300 font-semibold"
+        href="/projects/"
+      >
+        View all projects
+        <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+        </svg>
+      </a>
     </div>
   </Section>
 );

--- a/src/partials/ProjectList.tsx
+++ b/src/partials/ProjectList.tsx
@@ -1,187 +1,63 @@
-import {
-  ColorTags,
-  Project,
-  Section,
-  Tags,
-} from '@/components';
+import { Project, Section, Tags } from '@/components';
 import { GradientText } from '@/components/GradientText';
+import {
+  categoryLabels,
+  categoryOrder,
+  projects,
+} from '@/data/projects';
+import type { ProjectEntry } from '@/data/projects';
 
-const ProjectList = () => (
-  <Section
-    title={
-      <>
-        Recent <GradientText>Projects</GradientText>
-      </>
-    }
-  >
-    <div className="flex flex-col gap-6">
-      <Project
-        name="hw-core"
-        description="Cross platform hardware wallet interface. A Rust-based library implementing low-level wallet functionality, including Trezor Host Protocol."
-        link="https://github.com/hewigovens/hw-core"
-        img={{
-          src: '/assets/images/project-hw-core.png',
-          alt: 'hw-core',
-        }}
-        category={
-          <>
-            <Tags color={ColorTags.RUST}>Rust</Tags>
-            <Tags color={ColorTags.CYAN}>Hardware Wallet</Tags>
-            <Tags color={ColorTags.GREEN}>Trezor</Tags>
-            <Tags color={ColorTags.INDIGO}>BLE</Tags>
-          </>
-        }
-      />
-      <Project
-        name="amux"
-        description="A tiny Rust CLI that keeps your fleet of local AI/code agents organised inside tmux with consistent commands to launch, attach, detach, and prune sessions."
-        link="https://github.com/hewigovens/amux"
-        img={{
-          src: '/assets/images/project-amux.svg',
-          alt: 'amux CLI',
-        }}
-        category={
-          <>
-            <Tags color={ColorTags.RUST}>Rust</Tags>
-            <Tags color={ColorTags.SLATE}>CLI</Tags>
-            <Tags color={ColorTags.GREEN}>tmux</Tags>
-            <Tags color={ColorTags.INDIGO}>Agents</Tags>
-          </>
-        }
-      />
-      <Project
-        name="App Detective"
-        description="A tool to detect macOS apps' GUI tech stack, helping developers understand the underlying technologies used in applications."
-        link="https://github.com/hewigovens/app-detective"
-        img={{
-          src: '/assets/images/project-app-detective.png',
-          alt: 'App Detective',
-        }}
-        category={
-          <>
-            <Tags color={ColorTags.SWIFT}>Swift</Tags>
-            <Tags color={ColorTags.FUCHSIA}>macOS</Tags>
-            <Tags color={ColorTags.VIOLET}>Reverse Engineering</Tags>
-            <Tags color={ColorTags.EMERALD}>Diagnostics</Tags>
-          </>
-        }
-      />
-      <Project
-        name="Solana Primitives"
-        description="A Rust crate providing fundamental data structures and tools for constructing and submitting Solana transactions."
-        link="https://github.com/hewigovens/solana-primitives"
-        img={{
-          src: '/assets/images/project-cargo.png',
-          alt: 'Solana Primitives',
-        }}
-        category={
-          <>
-            <Tags color={ColorTags.RUST}>Rust</Tags>
-            <Tags color={ColorTags.LIME}>Blockchain</Tags>
-            <Tags color={ColorTags.VIOLET}>Solana</Tags>
-            <Tags color={ColorTags.INDIGO}>SDK</Tags>
-          </>
-        }
-      />
-      <Project
-        name="Staged Launcher"
-        description="The easiest way to manage and delay the launch of applications across different stages on your Mac."
-        link="https://github.com/hewigovens/StagedLauncher"
-        img={{
-          src: '/assets/images/project-staged-launcher.png',
-          alt: 'Staged Launcher',
-        }}
-        category={
-          <>
-            <Tags color={ColorTags.SWIFT}>Swift</Tags>
-            <Tags color={ColorTags.FUCHSIA}>macOS</Tags>
-            <Tags color={ColorTags.ROSE}>Productivity</Tags>
-            <Tags color={ColorTags.INDIGO}>Automation</Tags>
-          </>
-        }
-      />
-      <Project
-        name="Aya DevContainer"
-        description="DevContainer (Docker) image for Aya-rs, providing a pre-configured development environment for eBPF programming with Rust."
-        link="https://github.com/hewigovens/aya-devcontainer"
-        img={{
-          src: '/assets/images/project-aya-container.png',
-          alt: 'Aya DevContainer',
-        }}
-        category={
-          <>
-            <Tags color={ColorTags.RUST}>Rust</Tags>
-            <Tags color={ColorTags.BLUE}>Docker</Tags>
-            <Tags color={ColorTags.VIOLET}>eBPF</Tags>
-            <Tags color={ColorTags.EMERALD}>DevContainer</Tags>
-          </>
-        }
-      />
-      <Project
-        name="reqwest-enum"
-        description="Type-safe and enum style API for Rust, tt abstracts away repetitive boilerplate code like url formatting,
-        query / header encoding and response deserialization, plus async by default and lightweight JSON-RPC support."
-        link="https://github.com/hewigovens/reqwest-enum"
-        img={{
-          src: '/assets/images/project-cargo.png',
-          alt: 'Project Web Design',
-        }}
-        category={
-          <>
-            <Tags color={ColorTags.RUST}>Rust</Tags>
-            <Tags color={ColorTags.SWIFT}>Enum</Tags>
-            <Tags color={ColorTags.SKY}>HTTP</Tags>
-            <Tags color={ColorTags.LIME}>JSONRPC</Tags>
-          </>
-        }
-      />
-      <Project
-        name="Wallet Core"
-        description="Trust Wallet Core is an open-source, cross-platform, mobile-focused
-        library implementing low-level cryptographic wallet functionality
-        for a high number of blockchains."
-        link="https://github.com/trustwallet/wallet-core"
-        img={{ src: '/assets/images/project-wallet-core.png', alt: 'Wallet Core' }}
-        category={
-          <>
-            <Tags color={ColorTags.CPP}>C++</Tags>
-            <Tags color={ColorTags.YELLOW}>Cross Platform</Tags>
-            <Tags color={ColorTags.WEBASSEMBLY}>Web Assembly</Tags>
-            <Tags color={ColorTags.FUCHSIA}>SDK</Tags>
-          </>
-        }
-      />
-      <Project
-        name="Inspect"
-        description="Inspect is an action extension (works in both Safari, Chrome and Edge) that allows you to
-        inspect and export website's https certificate information."
-        link="https://apps.apple.com/us/app/inspect-view-tls-certificate/id1074957486"
-        img={{ src: '/assets/images/project-inspect.png', alt: 'Inspect iOS app' }}
-        category={
-          <>
-            <Tags color={ColorTags.SWIFT}>Swift</Tags>
-            <Tags color={ColorTags.INDIGO}>TLS</Tags>
-            <Tags color={ColorTags.BLUE}>OpenSSL</Tags>
-            <Tags color={ColorTags.FUCHSIA}>iOS</Tags>
-          </>
-        }
-      />
-      <Project
-        name="GhostTile"
-        description="Hide your running applications from Dock like a charm."
-        link="https://ghosttile.kernelpanic.im/"
-        img={{ src: '/assets/images/project-ghost.png', alt: 'GhostTile macOS app' }}
-        category={
-          <>
-            <Tags color={ColorTags.OBJC}>ObjcC</Tags>
-            <Tags color={ColorTags.GREEN}>XPC</Tags>
-            <Tags color={ColorTags.ROSE}>Code injection</Tags>
-            <Tags color={ColorTags.FUCHSIA}>macOS</Tags>
-          </>
-        }
-      />
-    </div>
-  </Section>
-);
+function resolveLink(entry: ProjectEntry): string {
+  return entry.link.kind === 'internal' ? entry.link.path : entry.link.url;
+}
+
+const ProjectList = () => {
+  const grouped = categoryOrder.map((cat) => ({
+    category: cat,
+    label: categoryLabels[cat],
+    items: projects.filter((p) => p.category === cat),
+  }));
+
+  return (
+    <Section
+      title={
+        <>
+          Recent <GradientText>Projects</GradientText>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-10">
+        {grouped.map(({ category, label, items }) => (
+          <div key={category}>
+            <h3 className="text-lg font-semibold mb-4 text-gray-300">
+              {label.prefix}{' '}
+              <GradientText>{label.highlight}</GradientText>
+            </h3>
+            <div className="flex flex-col gap-6">
+              {items.map((entry) => (
+                <Project
+                  key={entry.name}
+                  name={entry.name}
+                  description={entry.description}
+                  link={resolveLink(entry)}
+                  img={entry.img}
+                  category={
+                    <>
+                      {entry.tags.map((tag) => (
+                        <Tags key={tag.label} color={tag.color}>
+                          {tag.label}
+                        </Tags>
+                      ))}
+                    </>
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Section>
+  );
+};
 
 export { ProjectList };

--- a/src/partials/ProjectsByCategory.tsx
+++ b/src/partials/ProjectsByCategory.tsx
@@ -1,0 +1,59 @@
+import { Project, Section, Tags } from '@/components';
+import { GradientText } from '@/components/GradientText';
+import {
+  categoryLabels,
+  categoryOrder,
+  projects,
+  resolveLink,
+} from '@/data/projects';
+
+const ProjectsByCategory = () => {
+  const grouped = categoryOrder.map((cat) => ({
+    category: cat,
+    label: categoryLabels[cat],
+    items: projects.filter((p) => p.category === cat),
+  }));
+
+  return (
+    <Section
+      title={
+        <>
+          All <GradientText>Projects</GradientText>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-10">
+        {grouped.map(({ category, label, items }) => (
+          <div key={category}>
+            <h3 className="text-lg font-semibold mb-4 text-gray-300">
+              {label.prefix}{' '}
+              <GradientText>{label.highlight}</GradientText>
+            </h3>
+            <div className="flex flex-col gap-6">
+              {items.map((entry) => (
+                <Project
+                  key={entry.name}
+                  name={entry.name}
+                  description={entry.description}
+                  link={resolveLink(entry)}
+                  img={entry.img}
+                  category={
+                    <>
+                      {entry.tags.map((tag) => (
+                        <Tags key={tag.label} color={tag.color}>
+                          {tag.label}
+                        </Tags>
+                      ))}
+                    </>
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Section>
+  );
+};
+
+export { ProjectsByCategory };


### PR DESCRIPTION
## Summary
- Extract hardcoded project data from `ProjectList.tsx` into a typed data file (`src/data/projects.ts`) with `ProjectCategory`, `ProjectLink`, and `ProjectEntry` types
- Refactor `ProjectList.tsx` to render projects grouped by category (Rust → macOS → iOS → Contributions) with `GradientText` section headings
- Add new **Anytime** project entry (timezone-aware world clock app)
- Create stub project pages at `/projects/anytime`, `/projects/inspect`, and `/projects/ghosttile` with consistent card layout, tag pills, and CTA buttons

## Test plan
- [x] `pnpm build` passes with no errors
- [x] Verify project list renders with category groupings on the home page
- [x] Verify each stub page loads: `/projects/anytime`, `/projects/inspect`, `/projects/ghosttile`
- [x] Verify internal links from project cards navigate to the correct stub pages