### PR TITLE
Fix Glance links

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -145,7 +145,7 @@ export const projects: ProjectEntry[] = [
     ],
     link: {
       kind: 'external',
-      url: 'https://a1.hewig.dev/staged/',
+      url: 'https://glance.hewig.dev/staged/',
     },
   },
   {

--- a/src/partials/Navbar.tsx
+++ b/src/partials/Navbar.tsx
@@ -42,7 +42,7 @@ const Navbar = () => (
             Projects
           </span>
         </NavMenuItem>
-        <NavMenuItem href="https://a1.hewig.dev">
+        <NavMenuItem href="https://glance.hewig.dev">
           <span className="inline-flex items-center gap-1">
             <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />


### PR DESCRIPTION
Updates the hewig.dev navbar Glance link from a1.hewig.dev to glance.hewig.dev, and moves the Staged Launcher project link from a1.hewig.dev/staged/ to glance.hewig.dev/staged/.\n\nVerification:\n- pnpm run build ✅\n- pnpm run lint ✅\n\nNote: pnpm run build-types currently fails because package.json references tsc but the repo does not install typescript.