### PR TITLE
Fix GhostTile project link

### DIFF
--- a/src/pages/projects/ghosttile.astro
+++ b/src/pages/projects/ghosttile.astro
@@ -35,7 +35,7 @@ const description =
         </div>
 
         <a
-          href="https://ghosttile.kernelpanic.im/"
+          href="https://ghosttile.hewig.dev"
           class="inline-block rounded-lg bg-cyan-600 px-6 py-3 font-semibold text-white transition hover:bg-cyan-700"
         >
           Visit GhostTile


### PR DESCRIPTION
Updates the GhostTile project CTA from the legacy kernelpanic.im host to https://ghosttile.hewig.dev.
Checks:
- npm run lint
- npm run build