### PR TITLE
Zoey's Lab apps live on zoeyslab.com now

### DIFF
--- a/src/pages/zoeys-lab.astro
+++ b/src/pages/zoeys-lab.astro
@@ -11,7 +11,7 @@ const apps = [
   {
     name: "Huely",
     tagline: "A colour-mixing lab",
-    url: "https://huely.hewig.dev",
+    url: "https://huely.zoeyslab.com",
     img: "/assets/images/project-huely.svg",
     blurb:
       "Drip cyan, magenta, yellow and black and watch them blend the way real ink does — magenta and yellow make red, not mud. Then turn the lights off and cross red, green and blue beams that add up to white instead. Two opposite kinds of colour over one engine.",
@@ -26,7 +26,7 @@ const apps = [
   {
     name: "Ditty",
     tagline: "A Morse code lab",
-    url: "https://ditty.hewig.dev",
+    url: "https://ditty.zoeyslab.com",
     img: "/assets/images/project-ditty.svg",
     blurb:
       "Tap for a dit, hold for a dah. Every mark is drawn as long as you held it, so the ratio that makes Morse readable — one for a dit, three for a dah — is something you can see before anyone explains it. Or send it as light from a signal lamp instead.",


### PR DESCRIPTION
The lab page's links and JSON-LD now point at huely.zoeyslab.com and ditty.zoeyslab.com — the apps' own domain — instead of the hewig.dev subdomains. The old hostnames redirect, so merge order doesn't matter.