### PR TITLE
Meta descriptions grow up: Bing flagged the short ones

### DIFF
--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -31,7 +31,8 @@ interface Props {
 const { page } = Astro.props as Props;
 
 const title = `${AppConfig.title} - Blog (${page.currentPage})`;
-const description = "Tao Xu (hewig)'s Devlog";
+const description =
+  "Blog posts by Tao Xu (hewig), a Tokyo-based software engineer: Rust and macOS development, crypto wallet infrastructure, AI coding agents, and life in Japan.";
 ---
 
 <Base head={{ title, description }}>

--- a/src/pages/posts/farewell-tw.md
+++ b/src/pages/posts/farewell-tw.md
@@ -1,7 +1,7 @@
 ---
 layout: '@/templates/BasePost.astro'
 title: Farewell to Trust Wallet
-description: Serendipity, ikigai, it's time to start a new journey.
+description: Saying goodbye to Trust Wallet after years as a core engineer — bittersweet reflections on serendipity, ikigai, and the start of a new journey.
 pubDate: 2024-04-12T00:00:00Z
 imgSrc: '/assets/images/image-tw-farewell.png'
 imgAlt: 'Trust Wallet farewell'

--- a/src/pages/posts/move-to-japan.md
+++ b/src/pages/posts/move-to-japan.md
@@ -1,7 +1,7 @@
 ---
 layout: '@/templates/BasePost.astro'
 title: Move to Japan
-description: The journey to Japan has been a transformative experience.
+description: Moving to Japan has been a transformative experience — a short note on the start of a new chapter in Tokyo, with cherry blossoms to mark the moment.
 pubDate: 2021-09-30T00:00:00Z
 imgSrc: '/assets/images/image-sakura.webp'
 imgAlt: 'Pink cherry blossoms (sakura) in Japan'

--- a/src/pages/posts/native-obsession.md
+++ b/src/pages/posts/native-obsession.md
@@ -1,7 +1,7 @@
 ---
 layout: '@/templates/BasePost.astro'
 title: 'Native Obsession'
-description: 'Exploring the philosophy of embracing native environments from hardware to cloud, crypto and AI.'
+description: 'Native is more than a marketing term: what it means to treat the default environment as first-class, from hardware to cloud, crypto and AI — and what you gain.'
 pubDate: 2025-06-04T00:00:00Z
 imgSrc: '/assets/images/native-concept.webp'
 imgAlt: 'Native concept image'

--- a/src/pages/posts/wallet-connect-skill.md
+++ b/src/pages/posts/wallet-connect-skill.md
@@ -1,7 +1,7 @@
 ---
 layout: '@/templates/BasePost.astro'
 title: 'Do AI Agents Really Need New Wallets?'
-description: AI agents don't need new wallets. They need a protocol to talk to the ones you already trust.
+description: AI agents don't need new wallets. They need a protocol to talk to the ones you already trust — a WalletConnect skill that keeps every approval in your hands.
 pubDate: 2026-02-15T00:00:00Z
 imgSrc: '/assets/images/image-post.webp'
 imgAlt: 'WalletConnect Skill'

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -3,7 +3,8 @@ import { ProjectsByCategory } from "@/partials/ProjectsByCategory";
 import Base from "@/templates/Base.astro";
 
 const title = "All Projects";
-const description = "Browse all projects by category.";
+const description =
+  "All of Tao Xu's projects by category: Rust libraries and tools, macOS and iOS apps, and open source contributions like Trust Wallet Core.";
 ---
 
 <Base head={{ title, description }}>

--- a/src/pages/projects/staged-launcher.astro
+++ b/src/pages/projects/staged-launcher.astro
@@ -4,7 +4,7 @@ import { ColorTags } from "@/components/Tags";
 import { breadcrumbNode, softwareAppNode } from "@/utils/seo";
 
 const description =
-  "The easiest way to manage and delay the launch of applications across different stages on your Mac.";
+  "Staged Launcher is the easiest way to manage and delay app launches across stages on your Mac, so the essentials start first and the rest wait their turn.";
 const url = "https://hewig.dev/projects/staged-launcher/";
 const site = "https://glance.hewig.dev/staged/";
 const releases =


### PR DESCRIPTION
Bing Webmaster Tools warned that meta descriptions on many pages are too short (its comfort zone is roughly 25–160 characters, and it leans toward the long end). An audit of all 27 built pages found seven offenders:

| Page | Before | After |
|---|---:|---:|
| `/posts/` (every paginated page) | **23** | 157 |
| `/projects/` | 32 | 137 |
| farewell-tw | 54 | 143 |
| move-to-japan | 58 | 148 |
| wallet-connect-skill | 93 | 157 |
| native-obsession | 96 | 159 |
| staged-launcher | 99 | 154 |

The blog index was the biggest one — 23 characters, below even Bing's floor, repeated across every `/posts/N/` page, which is why the warning said "many of your pages."

Each rewrite says what the page actually contains rather than padding: the blog index names the recurring topics, the wallet-connect post keeps its original hook and adds what the skill does, the projects index names the categories. All remaining site descriptions were audited and sit comfortably in range. `pnpm build` green; dist HTML verified to carry the new tags.